### PR TITLE
Really change to self::

### DIFF
--- a/src/JasonNZ/Jinput/Security.php
+++ b/src/JasonNZ/Jinput/Security.php
@@ -45,7 +45,7 @@ class Security {
 		{
 			while (list($key) = each($str))
 			{
-				$str[$key] = self->xss_clean($str[$key]);
+				$str[$key] = self::xss_clean($str[$key]);
 			}
 			return $str;
 		}


### PR DESCRIPTION
`self->` leads to `syntax error, unexpected '->' (T_OBJECT_OPERATOR)`
