### PR TITLE
Tweak for PHP 5.3 compatibility

### DIFF
--- a/src/JasonNZ/Jinput/Jinput.php
+++ b/src/JasonNZ/Jinput/Jinput.php
@@ -34,7 +34,7 @@ class Jinput extends Input {
 	public static function all()
 	{
 		$oldInput = Input::all();
-		$newInput = [];
+		$newInput = array();
 
 		foreach ($oldInput as $key => $value) {
 			$newInput[$key] = self::get2($value);


### PR DESCRIPTION
Laravel 4 only requires PHP 5.3, so it leaves people out to use 5.4 features that aren't required.
